### PR TITLE
Change the mousemove event listener to the body

### DIFF
--- a/src/components/Rotate/hooks/useHandler.ts
+++ b/src/components/Rotate/hooks/useHandler.ts
@@ -110,7 +110,7 @@ export const useHandler = (
     }
 
     const clearEvent = () => {
-      dragBarRef.current.removeEventListener("mousemove", moveEvent, false)
+      // dragBarRef.current.removeEventListener("mousemove", moveEvent, false)
       dragBarRef.current.removeEventListener("touchmove", moveEvent, { passive: false })
 
       dragBarRef.current.removeEventListener( "mouseup", upEvent, false)
@@ -119,11 +119,12 @@ export const useHandler = (
       dragBarRef.current.removeEventListener( "mouseleave", leaveDragBlockEvent, false)
       dragBarRef.current.removeEventListener("touchend", upEvent, false)
 
+      document.body.removeEventListener("mousemove", moveEvent, false)
       document.body.removeEventListener("mouseleave", upEvent, false)
       document.body.removeEventListener("mouseup", leaveUpEvent, false)
     }
 
-    dragBarRef.current.addEventListener("mousemove", moveEvent, false)
+    // dragBarRef.current.addEventListener("mousemove", moveEvent, false)
     dragBarRef.current.addEventListener("touchmove", moveEvent, { passive: false })
     dragBarRef.current.addEventListener( "mouseup", upEvent, false)
     // dragBarRef.current.addEventListener( "mouseout", upEvent, false)
@@ -131,6 +132,7 @@ export const useHandler = (
     dragBarRef.current.addEventListener( "mouseleave", leaveDragBlockEvent, false)
     dragBarRef.current.addEventListener("touchend", upEvent, false)
 
+    document.body.addEventListener("mousemove", moveEvent, false)
     document.body.addEventListener("mouseleave", upEvent, false)
     document.body.addEventListener("mouseup", leaveUpEvent, false)
   }, [dragBlockRef, dragBarRef, event, clear])

--- a/src/components/Slide/hooks/useHandler.ts
+++ b/src/components/Slide/hooks/useHandler.ts
@@ -116,7 +116,7 @@ export const useHandler = (
     }
 
     const clearEvent = () => {
-      dragBarRef.current.removeEventListener("mousemove", moveEvent, false)
+      // dragBarRef.current.removeEventListener("mousemove", moveEvent, false)
       dragBarRef.current.removeEventListener("touchmove", moveEvent, { passive: false })
 
       dragBarRef.current.removeEventListener( "mouseup", upEvent, false)
@@ -125,11 +125,12 @@ export const useHandler = (
       dragBarRef.current.removeEventListener( "mouseleave", leaveDragBlockEvent, false)
       dragBarRef.current.removeEventListener("touchend", upEvent, false)
 
+      document.body.removeEventListener("mousemove", moveEvent, false)
       document.body.removeEventListener("mouseleave", upEvent, false)
       document.body.removeEventListener("mouseup", leaveUpEvent, false)
     }
 
-    dragBarRef.current.addEventListener("mousemove", moveEvent, false)
+    // dragBarRef.current.addEventListener("mousemove", moveEvent, false)
     dragBarRef.current.addEventListener("touchmove", moveEvent, { passive: false })
     dragBarRef.current.addEventListener( "mouseup", upEvent, false)
     // dragBarRef.current.addEventListener( "mouseout", upEvent, false)
@@ -137,6 +138,7 @@ export const useHandler = (
     dragBarRef.current.addEventListener( "mouseleave", leaveDragBlockEvent, false)
     dragBarRef.current.addEventListener("touchend", upEvent, false)
 
+    document.body.addEventListener("mousemove", moveEvent, false)
     document.body.addEventListener("mouseleave", upEvent, false)
     document.body.addEventListener("mouseup", leaveUpEvent, false)
   }, [dragBlockRef, containerRef, data.thumbX, data.thumbY, tileRef, dragBarRef, event, clear])


### PR DESCRIPTION
- 将mousemove事件监听放在body上，这样拖动滑块时即使鼠标离开了滑块，也能继续拖动
- 移动端因为没有类似于mouseleave的事件，导致即使不在body上监听move事件，效果也一样，这样反而将移动和pc端两种交互统一了
- 改动作为新feature
- https://github.com/wenlng/go-captcha-react/issues/3